### PR TITLE
Add ImmoScout24 listing saver Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# Projects
+# ImmoScout24 Saver
+
+Chrome-Erweiterung zum Speichern von Inseraten vom Immobilienportal ImmoScout24. Nach einem Klick auf den Button im Popup werden Name des Inserats, Wohnfläche, Preis, Datum sowie – falls vorhanden – die Adresse erfasst. Zusätzlich berechnet das Plugin den Preis pro Quadratmeter und speichert alle Daten in `chrome.storage.local`.
+
+## Nutzung
+
+1. Öffne `chrome://extensions/` in Chrome.
+2. Aktiviere den Entwicklermodus.
+3. Klicke auf **Entpackte Erweiterung laden** und wähle dieses Verzeichnis aus.
+4. Öffne ein ImmoScout24-Inserat und klicke im Popup der Erweiterung auf **Inserat speichern**.
+
+Die gespeicherten Daten sind unter dem Schlüssel `listings` in `chrome.storage.local` abgelegt.

--- a/content.js
+++ b/content.js
@@ -1,0 +1,64 @@
+function parseNumber(value) {
+  if (!value) return null;
+  const normalized = value.toString().replace(/[^0-9.,]/g, '').replace(',', '.');
+  const num = parseFloat(normalized);
+  return isNaN(num) ? null : num;
+}
+
+function extractListing() {
+  let data = {};
+  const jsonLd = document.querySelector('script[type="application/ld+json"]');
+  if (jsonLd) {
+    try {
+      const parsed = JSON.parse(jsonLd.textContent);
+      data = Array.isArray(parsed) ? parsed[0] : parsed;
+    } catch (e) {
+      // ignore parsing errors
+    }
+  }
+
+  const name = data.name || data.headline || document.querySelector('h1')?.innerText.trim() || '';
+
+  let size = parseNumber(data.floorSize);
+  if (!size) {
+    const sizeEl = Array.from(document.querySelectorAll('span, dd'))
+      .find(el => /\b(m²|qm)/i.test(el.textContent));
+    size = parseNumber(sizeEl?.textContent);
+  }
+
+  const price = parseNumber(data?.offers?.price) ||
+    parseNumber(Array.from(document.querySelectorAll('span, dd'))
+      .find(el => /€/.test(el.textContent))?.textContent);
+
+  const date = data.datePublished || new Date().toISOString().split('T')[0];
+
+  let address = '';
+  if (data.address) {
+    const addr = data.address;
+    address = [addr.streetAddress, addr.postalCode, addr.addressLocality]
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  const pricePerSqm = price && size ? Math.round((price / size) * 100) / 100 : null;
+
+  return { name, size, price, date, address, pricePerSqm };
+}
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'SAVE_LISTING') {
+    const listing = extractListing();
+    if (!listing.name && !listing.price) {
+      sendResponse({ success: false });
+      return;
+    }
+    chrome.storage.local.get({ listings: [] }, (result) => {
+      const listings = result.listings;
+      listings.push(listing);
+      chrome.storage.local.set({ listings }, () => {
+        sendResponse({ success: true, listing });
+      });
+    });
+    return true; // indicates async response
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "ImmoScout24 Saver",
+  "version": "1.0",
+  "description": "Speichert Immobilieninserate von ImmoScout24.",
+  "permissions": ["storage", "activeTab"],
+  "host_permissions": ["https://www.immobilienscout24.de/*"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "ImmoScout24 Inserat speichern"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.immobilienscout24.de/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <title>ImmoScout24 Saver</title>
+  <style>
+    body { min-width: 200px; font-family: Arial, sans-serif; }
+    button { padding: 8px 12px; }
+    #status { margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <button id="saveBtn">Inserat speichern</button>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,16 @@
+document.getElementById('saveBtn').addEventListener('click', () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const tab = tabs[0];
+    if (!tab) {
+      return;
+    }
+    chrome.tabs.sendMessage(tab.id, { action: 'SAVE_LISTING' }, (response) => {
+      const statusEl = document.getElementById('status');
+      if (response && response.success) {
+        statusEl.textContent = 'Inserat gespeichert.';
+      } else {
+        statusEl.textContent = 'Konnte keine Daten speichern.';
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Chrome extension to save ImmoScout24 listings
- parse listing details and compute price per square meter
- document how to load and use the extension

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689322f842cc83279ae0b897c76f3b95