### PR TITLE
Add saved listings viewer in popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -11,7 +11,10 @@
 </head>
 <body>
   <button id="saveBtn">Inserat speichern</button>
+  <button id="viewBtn">Gespeicherte Inserate</button>
   <div id="status"></div>
+  <ul id="listings"></ul>
+  <div id="details"></div>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,16 +1,50 @@
-document.getElementById('saveBtn').addEventListener('click', () => {
+const saveBtn = document.getElementById('saveBtn');
+const viewBtn = document.getElementById('viewBtn');
+const statusEl = document.getElementById('status');
+const listingsEl = document.getElementById('listings');
+const detailsEl = document.getElementById('details');
+
+saveBtn.addEventListener('click', () => {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     const tab = tabs[0];
     if (!tab) {
       return;
     }
     chrome.tabs.sendMessage(tab.id, { action: 'SAVE_LISTING' }, (response) => {
-      const statusEl = document.getElementById('status');
       if (response && response.success) {
         statusEl.textContent = 'Inserat gespeichert.';
       } else {
         statusEl.textContent = 'Konnte keine Daten speichern.';
       }
+    });
+  });
+});
+
+function showDetails(listing) {
+  detailsEl.innerHTML = `
+    <strong>${listing.name}</strong><br>
+    Größe: ${listing.size ?? ''}<br>
+    Preis: ${listing.price ?? ''}<br>
+    Datum: ${listing.date ?? ''}<br>
+    Adresse: ${listing.address ?? ''}<br>
+    Preis pro m²: ${listing.pricePerSqm ?? ''}
+  `;
+}
+
+viewBtn.addEventListener('click', () => {
+  chrome.storage.local.get({ listings: [] }, (result) => {
+    const listings = result.listings.sort((a, b) => new Date(b.date) - new Date(a.date));
+    listingsEl.innerHTML = '';
+    detailsEl.innerHTML = '';
+    if (listings.length === 0) {
+      listingsEl.textContent = 'Keine Inserate gespeichert.';
+      return;
+    }
+    listings.forEach((listing) => {
+      const li = document.createElement('li');
+      li.textContent = `${listing.name} - ${listing.date}`;
+      li.addEventListener('click', () => showDetails(listing));
+      listingsEl.appendChild(li);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add button to view saved ImmoScout24 listings
- list entries with name and date sorted descending and show details on click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689326fec8a083278022903c348ec425