### PR TITLE
Save listing URL and prevent duplicate entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ImmoScout24 Saver
 
-Chrome-Erweiterung zum Speichern von Inseraten vom Immobilienportal ImmoScout24. Nach einem Klick auf den Button im Popup werden Name des Inserats, Wohnfläche, Preis, Datum sowie – falls vorhanden – die Adresse erfasst. Zusätzlich berechnet das Plugin den Preis pro Quadratmeter und speichert alle Daten in `chrome.storage.local`.
+Chrome-Erweiterung zum Speichern von Inseraten vom Immobilienportal ImmoScout24. Nach einem Klick auf den Button im Popup werden Name des Inserats, Wohnfläche, Preis, Datum sowie – falls vorhanden – die Adresse und die URL erfasst. Zusätzlich berechnet das Plugin den Preis pro Quadratmeter und speichert alle Daten in `chrome.storage.local`. Bereits gespeicherte Inserate werden beim erneuten Speichern aktualisiert.
 
 ## Nutzung
 
@@ -9,4 +9,4 @@ Chrome-Erweiterung zum Speichern von Inseraten vom Immobilienportal ImmoScout24.
 3. Klicke auf **Entpackte Erweiterung laden** und wähle dieses Verzeichnis aus.
 4. Öffne ein ImmoScout24-Inserat und klicke im Popup der Erweiterung auf **Inserat speichern**.
 
-Die gespeicherten Daten sind unter dem Schlüssel `listings` in `chrome.storage.local` abgelegt.
+Die gespeicherten Daten sind unter dem Schlüssel `listings` in `chrome.storage.local` abgelegt. In der Liste gespeicherter Inserate können Details angezeigt und der Link zum Original-Inserat geöffnet werden.

--- a/content.js
+++ b/content.js
@@ -68,7 +68,9 @@ function extractListing() {
 
   const pricePerSqm = price && size ? Math.round((price / size) * 100) / 100 : null;
 
-  return { name, size, price, date, address, pricePerSqm };
+  const url = window.location.href;
+
+  return { name, size, price, date, address, pricePerSqm, url };
 }
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -80,9 +82,16 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     }
     chrome.storage.local.get({ listings: [] }, (result) => {
       const listings = result.listings;
-      listings.push(listing);
+      const existingIndex = listings.findIndex(l => l.url === listing.url);
+      let updated = false;
+      if (existingIndex >= 0) {
+        listings[existingIndex] = listing;
+        updated = true;
+      } else {
+        listings.push(listing);
+      }
       chrome.storage.local.set({ listings }, () => {
-        sendResponse({ success: true, listing });
+        sendResponse({ success: true, listing, updated });
       });
     });
     return true; // indicates async response

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "ImmoScout24 Saver",
   "version": "1.0",
   "description": "Speichert Immobilieninserate von ImmoScout24.",
-  "permissions": ["storage", "activeTab"],
+  "permissions": ["storage", "activeTab", "tabs"],
   "host_permissions": ["https://www.immobilienscout24.de/*"],
   "action": {
     "default_popup": "popup.html",

--- a/popup.js
+++ b/popup.js
@@ -12,7 +12,7 @@ saveBtn.addEventListener('click', () => {
     }
     chrome.tabs.sendMessage(tab.id, { action: 'SAVE_LISTING' }, (response) => {
       if (response && response.success) {
-        statusEl.textContent = 'Inserat gespeichert.';
+        statusEl.textContent = response.updated ? 'Inserat aktualisiert.' : 'Inserat gespeichert.';
       } else {
         statusEl.textContent = 'Konnte keine Daten speichern.';
       }
@@ -21,13 +21,15 @@ saveBtn.addEventListener('click', () => {
 });
 
 function showDetails(listing) {
+  const link = listing.url ? `<a href="${listing.url}" target="_blank">Zum Inserat</a><br>` : '';
   detailsEl.innerHTML = `
     <strong>${listing.name}</strong><br>
     Größe: ${listing.size ?? ''}<br>
     Preis: ${listing.price ?? ''}<br>
     Datum: ${listing.date ?? ''}<br>
     Adresse: ${listing.address ?? ''}<br>
-    Preis pro m²: ${listing.pricePerSqm ?? ''}
+    Preis pro m²: ${listing.pricePerSqm ?? ''}<br>
+    ${link}
   `;
 }
 


### PR DESCRIPTION
## Summary
- store the page URL when extracting listing data
- update or insert listing based on URL to avoid duplicates
- show link to the original listing and update messages in popup
- document URL handling and add `tabs` permission

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689916f2c1208327ad6c1c123bede479