### PR TITLE
Add delete and reload controls to popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -4,14 +4,25 @@
   <meta charset="UTF-8" />
   <title>ImmoScout24 Saver</title>
   <style>
-    body { min-width: 200px; font-family: Arial, sans-serif; }
+    body { min-width: 200px; font-family: Arial, sans-serif; position: relative; }
     button { padding: 8px 12px; }
     #status { margin-top: 8px; }
+    #reloadBtn {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      padding: 0;
+    }
   </style>
 </head>
 <body>
+  <button id="reloadBtn" title="Aktualisieren">&#x21bb;</button>
   <button id="saveBtn">Inserat speichern</button>
   <button id="viewBtn">Gespeicherte Inserate</button>
+  <button id="deleteBtn">Löschen</button>
   <div id="status"></div>
   <ul id="listings"></ul>
   <div id="details"></div>

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,7 @@
 const saveBtn = document.getElementById('saveBtn');
 const viewBtn = document.getElementById('viewBtn');
+const deleteBtn = document.getElementById('deleteBtn');
+const reloadBtn = document.getElementById('reloadBtn');
 const statusEl = document.getElementById('status');
 const listingsEl = document.getElementById('listings');
 const detailsEl = document.getElementById('details');
@@ -49,4 +51,16 @@ viewBtn.addEventListener('click', () => {
       listingsEl.appendChild(li);
     });
   });
+});
+
+deleteBtn.addEventListener('click', () => {
+  chrome.storage.local.remove('listings', () => {
+    statusEl.textContent = 'Alle Inserate gelöscht.';
+    listingsEl.innerHTML = '';
+    detailsEl.innerHTML = '';
+  });
+});
+
+reloadBtn.addEventListener('click', () => {
+  chrome.runtime.reload();
 });


### PR DESCRIPTION
## Summary
- Add refresh icon that reloads extension for quick updates
- Add delete button to clear all stored listings and reset UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991b188e9c83278fafc667737d2d33