### PR TITLE
Improve listing popup formatting

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -4,8 +4,17 @@
   <meta charset="UTF-8" />
   <title>ImmoScout24 Saver</title>
   <style>
-    body { min-width: 200px; font-family: Arial, sans-serif; position: relative; }
-    button { padding: 8px 12px; }
+    body {
+      min-width: 200px;
+      font-family: Arial, sans-serif;
+      position: relative;
+      font-size: 12px;
+    }
+    button {
+      padding: 4px 8px;
+      width: 160px;
+      font-size: 12px;
+    }
     #status { margin-top: 8px; }
     #reloadBtn {
       position: absolute;
@@ -15,6 +24,16 @@
       background: transparent;
       cursor: pointer;
       padding: 0;
+      width: auto;
+    }
+    #listings {
+      border-collapse: collapse;
+      width: 100%;
+    }
+    #listings td {
+      border-bottom: 1px solid black;
+      padding: 4px;
+      cursor: pointer;
     }
   </style>
 </head>
@@ -24,7 +43,7 @@
   <button id="viewBtn">Gespeicherte Inserate</button>
   <button id="deleteBtn">Löschen</button>
   <div id="status"></div>
-  <ul id="listings"></ul>
+  <table id="listings"></table>
   <div id="details"></div>
   <script src="popup.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- make popup buttons uniform and smaller
- show listing entries in a table with separators and locale-aware formatting
- toggle listing details open/closed on repeated clicks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68992161881c83279902c6a36da8cc20