### PR TITLE
Add duplicate entry checker with reset icon

### DIFF
--- a/content.js
+++ b/content.js
@@ -101,4 +101,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     });
     return true; // indicates async response
   }
+  if (request.action === 'GET_LISTING') {
+    const listing = extractListing();
+    if (!listing.name && !listing.price) {
+      sendResponse({ success: false });
+      return;
+    }
+    sendResponse({ success: true, listing });
+  }
 });

--- a/popup.html
+++ b/popup.html
@@ -16,9 +16,9 @@
       font-size: 12px;
     }
     #status { margin-top: 8px; }
-    #reloadBtn {
+    #checkBtn,
+    #resetBtn {
       position: absolute;
-      top: 4px;
       right: 4px;
       border: none;
       background: transparent;
@@ -26,6 +26,8 @@
       padding: 0;
       width: auto;
     }
+    #checkBtn { top: 4px; }
+    #resetBtn { top: 28px; }
     #listings {
       border-collapse: collapse;
       width: 100%;
@@ -38,7 +40,8 @@
   </style>
 </head>
 <body>
-  <button id="reloadBtn" title="Aktualisieren">&#x21bb;</button>
+  <button id="checkBtn" title="Einträge prüfen">&#x2714;</button>
+  <button id="resetBtn" title="Farben zurücksetzen">&#x21ba;</button>
   <button id="saveBtn">Inserat speichern</button>
   <button id="viewBtn">Gespeicherte Inserate</button>
   <button id="deleteBtn">Löschen</button>


### PR DESCRIPTION
## Summary
- replace reload button with `Einträge prüfen` checkmark button
- highlight saved listings matching current page by name, address, size (green for all three, yellow for two)
- add reset button to clear highlighting

## Testing
- `node --check popup.js`
- `node --check content.js`


------
https://chatgpt.com/codex/tasks/task_e_689a40312d388327935d173c70a59034